### PR TITLE
Add findutils to driver image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL io.k8s.description="Habana Labs Driver allows deploying matching driver / 
 
 COPY --from=builder --chown=0:0 /home/builder/habanalabs/usr/src/habanalabs-${HABANA_VERSION}/drivers/misc/habanalabs/habanalabs.ko.xz /opt/lib/modules/${KERNEL_VERSION}.${ARCH}/extra/habanalabs.ko.xz
 COPY --from=builder --chown=0:0 /home/builder/habanalabs/lib/firmware/habanalabs/gaudi /opt/lib/firmware/habanalabs/gaudi
-RUN microdnf install -y kmod util-linux && microdnf clean all \
+RUN microdnf install -y kmod util-linux findutils && microdnf clean all \
     && touch /opt/lib/modules/${KERNEL_VERSION}.${ARCH}/modules.builtin \
     && touch /opt/lib/modules/${KERNEL_VERSION}.${ARCH}/modules.order \
     && depmod -b /opt ${KERNEL_VERSION}.${ARCH}


### PR DESCRIPTION
The `ubi-minimal` base image does not currently container `find` and `xargs`. KMM requires the [latter](https://github.com/kubernetes-sigs/kernel-module-management/blob/main/internal/daemonset/daemonset.go#L422) to cleanup the firmware files after the driver gets unloaded.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>